### PR TITLE
#322 - Adding Support for External Authorization. Use separate ESI auths for Login and ESI Pull

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,12 @@ MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS=noreply@localhost.local
 MAIL_FROM_NAME='SeAT Administrator'
 
+# Login Client /Secret / Callback Settings. Use these settings for User Log In
+LOGIN_CLIENT_ID=null
+LOGIN_CLIENT_SECRET=null
+LOGIN_CALLBACK_URL=http://seat.local/auth/eve/callback
+
+# Settings for ESEYE - Either Same as Login or Adjust to use same client_id/sectret_key as your External Auth provider
+EXTERNAL_AUTH=FALSE
 EVE_CLIENT_ID=null
 EVE_CLIENT_SECRET=null
-EVE_CALLBACK_URL=https://seat.local/auth/eve/callback

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,10 @@
 Please don't log issues for general discussions or non code problems. Instead, join us on Slack for a chat.
 
-https://eveseat.github.io/docs/about/contact/
+http://seat-docs.readthedocs.io/en/latest/contact/
 
 For some help on where to find logs, put SeAT into DEBUG mode etc, please refer to the following link:
 
-https://eveseat.github.io/docs/about/reporting_bugs/
+http://seat-docs.readthedocs.io/en/latest/reporting_bugs/
 
 Thanks for wanting to report an issue you've found in SeAT. Please delete
 this text and fill in the template below. If you are unsure about something,

--- a/config/services.php
+++ b/config/services.php
@@ -38,10 +38,15 @@ return [
     // If you want to make use of SSO via EVEOnline, create
     // an application at https://developers.eveonline.com/applications
     // and fill in the ClientID and ClientSecret in the .env file
+    'evelogin' => [
+        'client_id'     => env('LOGIN_CLIENT_ID'),
+        'client_secret' => env('LOGIN_CLIENT_SECRET'),
+        'redirect'      => env('LOGIN_CALLBACK_URL'),
+    ],
+    
     'eveonline' => [
         'client_id'     => env('EVE_CLIENT_ID'),
         'client_secret' => env('EVE_CLIENT_SECRET'),
-        'redirect'      => env('EVE_CALLBACK_URL'),
     ],
 
 ];

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ SeAT: A Simple, EVE Online API Tool and Corporation Manager
 <a href="https://packagist.org/packages/eveseat/seat"><img src="https://poser.pugx.org/eveseat/seat/v/stable" /></a>
 <a href="https://packagist.org/packages/eveseat/seat"><img src="https://poser.pugx.org/eveseat/seat/v/unstable" /></a>
 <a href="https://packagist.org/packages/eveseat/seat"><img src="https://poser.pugx.org/eveseat/seat/license" /></a>
+<a href="http://seat-docs.readthedocs.org/en/latest/"><img src="https://readthedocs.org/projects/seat-docs/badge/?version=latest" /></a>
 <a href="https://eveseat-slack.herokuapp.com/"><img src="https://eveseat-slack.herokuapp.com/badge.svg" /></a>
 <a href="https://styleci.io/repos/41199860"><img src="https://styleci.io/repos/41199860/shield?branch=master" alt="StyleCI"></a>
 
@@ -48,7 +49,7 @@ For the **actual** SeAT source, please refer to the following package repositori
 | [web](https://github.com/eveseat/web) | [![Latest Stable Version](https://poser.pugx.org/eveseat/web/v/stable)](https://packagist.org/packages/eveseat/web) | [![Total Downloads](https://poser.pugx.org/eveseat/web/downloads)](https://packagist.org/packages/eveseat/web) | [![Code Climate](https://codeclimate.com/github/eveseat/web/badges/gpa.svg)](https://codeclimate.com/github/eveseat/web) |
 
 ## documentation & installation
-Please refer to the [documentation](https://eveseat.github.io/docs/) for installation instructions, upgrade guides and more.
+Please refer to the [documentation](http://seat-docs.rtfd.org) for installation instructions, upgrade guides and more.
 
 ## security
 If you find any security vulnerabilities within SeAT, please send an email to theninjabag@gmail.com to address instead of creating a public Github issue.
@@ -58,4 +59,3 @@ If you find any security vulnerabilities within SeAT, please send an email to th
 
 ## donate
 If you like SeAT, please consider donating ISK in game to [qu1ckkkk](https://gate.eveonline.com/Profile/qu1ckkkk) or via [paypal](https://www.paypal.me/leonjza).
-


### PR DESCRIPTION
This is part of possible changes for allowing the use of an External Auth system to create users and ESI keys from a 3rd party auth system.

These changes ...

    Use a different Client_id/Secret_key pair that matches the External Auth system for the ESI data pull
    Prevent Users from Logging in unless a user has already been created by the external Auth system

Changes are also made to eveseat/web to support this.