### PR TITLE
use propper quotes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS=noreply@localhost.local
-MAIL_FROM_NAME='SeAT Administrator'
+MAIL_FROM_NAME="SeAT Administrator"
 
 EVE_CLIENT_ID=null
 EVE_CLIENT_SECRET=null


### PR DESCRIPTION
After `Updating laravel/framework (v5.5.44 => v5.5.45): Downloading (100%)`

this line caused an error:
```
 @php artisan package:discover

In Parser.php line 76:

  Dotenv values containing spaces must be surrounded by quotes.


Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1
```
this PR worked for me