### PR TITLE
fix(jobs): increase retry delay to be greater than timeout

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -62,7 +62,7 @@ return [
             'driver'      => 'redis',
             'connection'  => 'default',
             'queue'       => env('REDIS_QUEUE', 'default'),
-            'retry_after' => 90,
+            'retry_after' => 960, // 16 minutes (must be greater than timeout)
             'block_for' => null,
         ],
 


### PR DESCRIPTION
> The --timeout value should always be at least several seconds shorter than your retry_after configuration value. This will ensure that a worker processing a given job is always killed before the job is retried. If your --timeout option is longer than your retry_after configuration value, your jobs may be processed twice.

https://laravel.com/docs/6.x/queues#job-expirations-and-timeouts