### PR TITLE
fix: restrict CORS allowed origins and methods

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -17,13 +17,13 @@ return [
 
     'paths' => ['api/*'],
 
-    'allowed_methods' => ['*'],
+    'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => [env('APP_URL', 'http://localhost')],
 
     'allowed_origins_patterns' => [],
 
-    'allowed_headers' => ['*'],
+    'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Token'],
 
     'exposed_headers' => [],
 


### PR DESCRIPTION
## Security Fix: Overly Permissive CORS Policy

### Vulnerability

The CORS configuration used wildcard values for `allowed_origins`, `allowed_methods`, and `allowed_headers`:

```php
'allowed_methods' => ['*'],
'allowed_origins' => ['*'],
'allowed_headers' => ['*'],
```

This allows any external website to make cross-origin requests to the SeAT API (`api/*` routes).

### Impact

While `supports_credentials` is set to `false` (which prevents cookie-based CSRF), the wildcard origin policy still presents risks:

- Any malicious website can send cross-origin requests to the SeAT API using a victim's API token if it is stored in `localStorage` or accessible via JavaScript
- Exposes the API surface to cross-origin enumeration and data extraction attacks
- Violates the principle of least privilege for API access

### Fix

- `allowed_origins` is now restricted to `APP_URL` (the configured application URL)
- `allowed_methods` now uses an explicit list instead of a wildcard
- `allowed_headers` now uses an explicit list covering only what SeAT actually needs

### References

- [OWASP: CORS Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#cross-origin-resource-sharing-cors)
- [MDN: Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
- [PortSwigger: CORS vulnerabilities](https://portswigger.net/web-security/cors)